### PR TITLE
Catch and clear UART overrun error condition.

### DIFF
--- a/drivers/uart_syslink.adb
+++ b/drivers/uart_syslink.adb
@@ -325,6 +325,19 @@ package body UART_Syslink is
             Clear_Status (NRF_USART, Read_Data_Register_Not_Empty);
             Enqueue (Rx_Queue, Received_Byte);
             Byte_Avalaible := True;
+         elsif Status (NRF_USART, Overrun_Error_Indicated) then
+            --  RM0090 rev11 top of p 1001: overrun is cleared by
+            --  reading SR (which we've already done (twice, now?!)),
+            --  then reading DR.
+            --
+            --  We got here because the DR was empty. The incoming
+            --  character (the one that didn't make it from the shift
+            --  register to the DR) is discarded. We assume the
+            --  missing data can be recovered by higher-level
+            --  protocols.
+            Received_Byte := T_Uint8 (Current_Input (NRF_USART) and 16#FF#);
+            Clear_Status (NRF_USART, Read_Data_Register_Not_Empty);
+            Clear_Status (NRF_USART, Overrun_Error_Indicated);
          end if;
       end IRQ_Handler;
 

--- a/drivers/uart_syslink.adb
+++ b/drivers/uart_syslink.adb
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Certyflie                                   --
 --                                                                          --
---                     Copyright (C) 2015-2016, AdaCore                     --
+--                     Copyright (C) 2015-2017, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --


### PR DESCRIPTION
 This differs from the patch in issue #6, because I realised that we only get to the overrun case if there wasn’t a character in the data register to read; so just read & discard.

I called `Clear_Status`, because that’s what the original code did, but I’m not at all sure that’s necessary. The RM says the overflow status is cleared by reading SR, DR.

Similar comment for RXNE, I think.