### PR TITLE
Compatibility with CE 2018

### DIFF
--- a/crazyflie_support/src/log.adb
+++ b/crazyflie_support/src/log.adb
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Certyflie                                   --
 --                                                                          --
---                     Copyright (C) 2015-2017, AdaCore                     --
+--                     Copyright (C) 2015-2018, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -348,7 +348,6 @@ package body Log is
       Group_ID    : out Natural;
       Has_Succeed : out Boolean)
    is
-      use type Ada.Containers.Count_Type;
    begin
       Has_Succeed := False;
 
@@ -378,7 +377,6 @@ package body Log is
    is
       Group : Log_Group
       renames Log_Data.Log_Groups.Element_Access (Group_ID).all;
-      use type Ada.Containers.Count_Type;
    begin
       Has_Succeed := False;
 
@@ -752,8 +750,6 @@ package body Log is
 
          Ops_Settings : constant Ops_Settings_Array
            := T_Uint8_Array_To_Ops_Settings_Array (Ops_Settings_Raw);
-
-         use type Ada.Containers.Count_Type;
       begin
 
          for O of Ops_Settings loop

--- a/src/free_fall.adb
+++ b/src/free_fall.adb
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Certyflie                                   --
 --                                                                          --
---                     Copyright (C) 2015-2016, AdaCore                     --
+--                     Copyright (C) 2015-2018, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -107,7 +107,7 @@ is
 
       --  Try to detect landing only if a free fall has
       --  been detected and we still are in recovery mode.
-      if In_Recovery = 1 then
+      if In_Recovery then
 
          Derivative := Calculate_Last_Derivative (Landing_Data_Collector);
          --  If the derivative between two samples of the Z acceleration
@@ -131,8 +131,8 @@ is
    begin
       --  if the drone is in recovery mode and it has not recovered after
       --  the specified timeout, disable the free fall mode in emergency.
-      if In_Recovery = 1 and then Time_Since_Last_FF > RECOVERY_TIMEOUT then
-         In_Recovery := 0;
+      if In_Recovery and then Time_Since_Last_FF > RECOVERY_TIMEOUT then
+         In_Recovery := False;
          FF_Mode := DISABLED;
       end if;
    end FF_Watchdog;
@@ -150,7 +150,7 @@ is
    begin
       --  Check if FF Detection is disabled
       if FF_Mode = DISABLED then
-         In_Recovery := 0;
+         In_Recovery := False;
          return;
       end if;
 
@@ -163,17 +163,17 @@ is
 
       if Has_Landed then
          Last_Landing_Time := Clock;
-         In_Recovery := 0;
+         In_Recovery := False;
       end if;
 
       --  Detect if the drone is in free fall.
       FF_Detect_Free_Fall (Acc, Has_Detected_FF);
 
-      if In_Recovery = 0 and Has_Detected_FF and
+      if not In_Recovery and Has_Detected_FF and
         Time_Since_Last_Landing > STABILIZATION_PERIOD_AFTER_LANDING
       then
          Last_FF_Detected_Time := Clock;
-         In_Recovery := 1;
+         In_Recovery := True;
          Recovery_Thrust := MAX_RECOVERY_THRUST;
       end if;
 
@@ -191,7 +191,7 @@ is
       Pitch_Type          : in out RPY_Type) is
    begin
       --  If not in recovery, keep the original commands
-      if In_Recovery = 0 then
+      if not In_Recovery then
          return;
       end if;
 
@@ -214,8 +214,8 @@ is
       --  If not in recovery, keep the original thrust
       --  If the pilot has moved his joystick, the drone is not in recovery
       --  anymore
-      if In_Recovery = 0 or Thrust > 0 then
-         In_Recovery := 0;
+      if not In_Recovery or Thrust > 0 then
+         In_Recovery := False;
          return;
       end if;
 

--- a/src/free_fall.ads
+++ b/src/free_fall.ads
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Certyflie                                   --
 --                                                                          --
---                     Copyright (C) 2015-2016, AdaCore                     --
+--                     Copyright (C) 2015-2018, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -31,8 +31,7 @@ with Ada.Real_Time;           use Ada.Real_Time;
 
 with Commander;               use Commander;
 with IMU;                     use IMU;
-with Interfaces.C;            use Interfaces.C;
-with Interfaces.C.Extensions; use Interfaces.C.Extensions;
+with Interfaces.C;
 with Types;                   use Types;
 
 package Free_Fall
@@ -126,7 +125,7 @@ private
    --  Free Fall features internal variables.
    FF_Duration_Counter      : T_Uint16 := 0
      with Part_Of => FF_State;
-   In_Recovery              : bool := 0
+   In_Recovery              : Boolean := False
      with Part_Of => FF_State;
    Recovery_Thrust          : T_Uint16 := MAX_RECOVERY_THRUST
      with Part_Of => FF_State;


### PR DESCRIPTION
CE 2018 (and GCC 8) now reports a 'use type' which has no effect.
CE 2018 has changed the definition of Interfaces.C.Extensions.bool
incompatibly.

  * crazyflie_support/src/log.adb (Create_Log_Group): Remove
      ineffective 'use type'.
    (Append_Log_Variable_To_Group): Likewise.
    (Log_Append_To_Block): Likewise.

  * src/free_fall.ads (context): remove Interfaces.C.Extensions. Don't
      'use' Interfaces.C.
    (In_Recovery): now Boolean.
  * src/free_fall.adb: changed all uses of In_Recovery to be Boolean-
      compatible.